### PR TITLE
Fixes #10

### DIFF
--- a/src/search.py
+++ b/src/search.py
@@ -508,7 +508,7 @@ class DuckDuckGo(Suggest):
         return [d.get('phrase') for d in results]
 
     def url_for(self, query):
-        query = query + ' r:{0}'.format(self.options['lang'])
+        query = query.format(self.options['lang'])
         url = super(DuckDuckGo, self).url_for(query)
         log.debug(url)
         return url


### PR DESCRIPTION
This change makes DuckDuckGo search actually show instant answers for queries like [vim cheat sheet](https://duckduckgo.com/?q=vim+cheat+sheet&ia=cheatsheet). At least on my machine.